### PR TITLE
Add pricing section to Services page

### DIFF
--- a/docs/site-system.yaml
+++ b/docs/site-system.yaml
@@ -39,8 +39,10 @@ site_system:
       target_action: Route to Contact
       metric: Contact page visits from Services
       notes: >
-        Describe New Site and Site Rescue. "Starting from $1,000" as
-        a signal, not a full pricing table. No pricing page.
+        Describe New Site and Site Rescue. Includes a "What it costs"
+        section with two cards: Artist Site and Band/Musician Site,
+        both starting from $1,000, listing the included pages for each.
+        All pricing CTAs route to Contact.
 
     - name: Contact
       type: Converter

--- a/layouts/partials/modules/pricing-section.html
+++ b/layouts/partials/modules/pricing-section.html
@@ -1,0 +1,65 @@
+<section class="border-t border-cream/10">
+  <div class="max-w-6xl mx-auto px-6 py-24">
+
+    <h2 class="font-display text-3xl md:text-4xl text-cream font-light mb-16">What it costs</h2>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
+
+      <!-- Artist Site -->
+      <div class="border border-cream/10 p-10 hover:border-ember/40 transition-colors duration-300">
+        <div class="w-8 h-[2px] bg-ember mb-10"></div>
+        <h3 class="font-display text-2xl md:text-3xl text-cream font-light mb-2">Artist Site</h3>
+        <p class="text-cream/30 text-xs uppercase tracking-widest mb-8">Starting from</p>
+        <p class="font-display text-5xl text-cream font-light mb-10">$1,000</p>
+        <ul class="space-y-3 mb-10">
+          <li class="text-cream/55 text-sm leading-relaxed flex items-start gap-3">
+            <span class="text-ember mt-0.5">→</span>Home page
+          </li>
+          <li class="text-cream/55 text-sm leading-relaxed flex items-start gap-3">
+            <span class="text-ember mt-0.5">→</span>About the artist
+          </li>
+          <li class="text-cream/55 text-sm leading-relaxed flex items-start gap-3">
+            <span class="text-ember mt-0.5">→</span>Gallery
+          </li>
+          <li class="text-cream/55 text-sm leading-relaxed flex items-start gap-3">
+            <span class="text-ember mt-0.5">→</span>Events list
+          </li>
+          <li class="text-cream/55 text-sm leading-relaxed flex items-start gap-3">
+            <span class="text-ember mt-0.5">→</span>Contact page
+          </li>
+        </ul>
+      </div>
+
+      <!-- Band / Musician Site -->
+      <div class="border border-cream/10 p-10 hover:border-ember/40 transition-colors duration-300">
+        <div class="w-8 h-[2px] bg-ember mb-10"></div>
+        <h3 class="font-display text-2xl md:text-3xl text-cream font-light mb-2">Band &amp; Musician Site</h3>
+        <p class="text-cream/30 text-xs uppercase tracking-widest mb-8">Starting from</p>
+        <p class="font-display text-5xl text-cream font-light mb-10">$1,000</p>
+        <ul class="space-y-3 mb-10">
+          <li class="text-cream/55 text-sm leading-relaxed flex items-start gap-3">
+            <span class="text-ember mt-0.5">→</span>Home page
+          </li>
+          <li class="text-cream/55 text-sm leading-relaxed flex items-start gap-3">
+            <span class="text-ember mt-0.5">→</span>About the artist
+          </li>
+          <li class="text-cream/55 text-sm leading-relaxed flex items-start gap-3">
+            <span class="text-ember mt-0.5">→</span>Music page with streaming embeds
+          </li>
+          <li class="text-cream/55 text-sm leading-relaxed flex items-start gap-3">
+            <span class="text-ember mt-0.5">→</span>Upcoming shows
+          </li>
+          <li class="text-cream/55 text-sm leading-relaxed flex items-start gap-3">
+            <span class="text-ember mt-0.5">→</span>Merch page
+          </li>
+        </ul>
+      </div>
+
+    </div>
+
+    <p class="text-cream/35 text-sm leading-relaxed max-w-2xl">
+      Every site is custom — scope, timeline, and any add-ons are worked out in our first conversation.
+    </p>
+
+  </div>
+</section>

--- a/layouts/services/list.html
+++ b/layouts/services/list.html
@@ -9,6 +9,8 @@
 
   {{ partial "modules/service-block.html" . }}
 
+  {{ partial "modules/pricing-section.html" . }}
+
   <!-- Who it's for -->
   <section class="border-t border-cream/10">
     <div class="max-w-6xl mx-auto px-6 py-24">


### PR DESCRIPTION
Shows two $1,000 base-price configurations — Artist Site and Band/Musician Site —
each listing the included pages. Placed between "What I build" and "Who I work with"
on the Services page. Includes a note that scope and add-ons are discussed in the
first conversation, keeping the emphasis on contact rather than a rigid price menu.

https://claude.ai/code/session_015aZWL3vbM8CKaBKE8PMkZu